### PR TITLE
Update pid.c to include delta-time term

### DIFF
--- a/fpga/fpga_sw/src/pid.c
+++ b/fpga/fpga_sw/src/pid.c
@@ -20,7 +20,8 @@ void PID_Reset (Controller_PID* PID) {
 void PID_Update (Controller_PID* PID, double value) {
 // updates the controller with a single reading
     PID->P = value;
-    PID->I = (1-PID->Alpha)*PID->I + value;
+    //Left: accumulation of past terms with decay, Right: Riemann sum of current term (with delta time)
+    PID->I = (1-PID->Alpha)*PID->I + value/TIMER_RATE_IN_HZ;
     
     int i; 
     for (i = PID_NUM_OLD_VALUES-1; i > 0; i--)
@@ -32,7 +33,7 @@ void PID_Update (Controller_PID* PID, double value) {
     if (PID->num_values >= PID_NUM_OLD_VALUES-1) { // if enough values accumulated
         for (i = 1; i < PID_NUM_OLD_VALUES; i++)
             temp += PID->old_values[i-1] - PID->old_values[i];
-        PID->D = (float)temp / PID_NUM_OLD_VALUES;
+        PID->D = (float)temp / PID_NUM_OLD_VALUES * TIMER_RATE_IN_HZ; //average slope across several readings
     }
     else {
         PID->D = 0;


### PR DESCRIPTION
Delta time term is derived from how often the controller's calculate_pid() function is called.
In this case period (or delta-time) is 1/TIMER_RATE_IN_HZ
